### PR TITLE
In setups with more than 1 interface / bond, it does not work

### DIFF
--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -39,7 +39,7 @@ ovs_bridge_{{ interface_name }}:
 
 {%- set int_name = int.get('name', int_name) %}
 
-{%- if int.ovs_bridge is defined %}
+{%- if int.ovs_bridge is defined and interface_name == int.ovs_bridge %}
 
 add_int_to_ovs_bridge_{{ interface_name }}:
   cmd.run:

--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -41,7 +41,7 @@ ovs_bridge_{{ interface_name }}:
 
 {%- if int.ovs_bridge is defined and interface_name == int.ovs_bridge %}
 
-add_int_to_ovs_bridge_{{ interface_name }}:
+add_int_{{ int_name }}_to_ovs_bridge_{{ interface_name }}:
   cmd.run:
     - unless: ovs-vsctl show | grep {{ int_name }}
     - name: ovs-vsctl add-port {{ interface_name }} {{ int_name }}


### PR DESCRIPTION
If you have a second interface, that is also connecting to a (different) ovs_bridge, then it fails compilation:
    Data failed to compile:                                                                                       │
----------                                                                                                        │
    Rendering SLS 'base:linux.network.interface' failed: Conflicting ID 'add_int_to_ovs_bridge_br-prv'            │


Proposed pull request should fix this.