### PR TITLE
failover on hostname change

### DIFF
--- a/linux/network/hostname.sls
+++ b/linux/network/hostname.sls
@@ -18,7 +18,7 @@ linux_hostname_file:
 
 linux_enforce_hostname:
   cmd.wait:
-  - name: hostname {{ network.hostname }}
+  - name: "hostname {{ network.hostname }} || true"
 
 {#
 linux_hostname_hosts:


### PR DESCRIPTION
On some old/latest docker environments (ie: Travis) hostname change fails.
``` || true``` is the way to return 0 even on failure to recover the situation.
 Salt doc for cmd don't have anything like allow_fail.

Personally don't consider this a good solution anyway.