### PR TITLE
dont touch hostname if not needed

### DIFF
--- a/linux/network/hostname.sls
+++ b/linux/network/hostname.sls
@@ -19,6 +19,7 @@ linux_hostname_file:
 linux_enforce_hostname:
   cmd.wait:
   - name: hostname {{ network.hostname }}
+  - unless: test "$(hostname)" = "{{ network.hostname }}"
 
 {#
 linux_hostname_hosts:


### PR DESCRIPTION
safe way to avoid non necessary hostname change.. 

For reviewer: bit hesitate between  ```$(hostname -s)``` vs used $(hostname)