### PR TITLE
remove trailing line, causing every deployment to update the file and…

### DIFF
--- a/linux/files/hostname
+++ b/linux/files/hostname
@@ -1,2 +1,1 @@
 {{ pillar.linux.system.name }}
-


### PR DESCRIPTION
… trigger hostname enforce -> still causes issues on travis docker.

Some internet sources claims:
/etc/hostname should not contain comments or empty lines.
