### PR TITLE
Use check_disk thresholds from pillar data

### DIFF
--- a/linux/meta/sensu.yml
+++ b/linux/meta/sensu.yml
@@ -27,7 +27,7 @@ check:
     - {{ system.name|replace('.', '-') }}-{{ system.domain|replace('.', '-') }}
 {%- endif %}
   local_linux_storage_disk_usage:
-    command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_disk -w 15% -c 5% -p / -p /var -p /usr -p /tmp -p /var/log"
+    command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_disk -w" {{ monitoring.disk.get('warn', '15%') }} " -c " {{ monitoring.disk.get('critical', '5%') }}  " -p / -p /var -p /usr -p /tmp -p /var/log"
     interval: 60
     occurrences: 1
     subscribers:


### PR DESCRIPTION
In some environments, the instance's given disk size is such that it is
allowed to expand and fill the host's disk, pushing the host disk over the
specified thresholds. This allows modification of these thresholds via pillar
data.