### PR TITLE
require linux_packages install in repo state

### DIFF
--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -58,6 +58,8 @@ linux_repo_{{ name }}:
   {%- if repo.key_url is defined %}
   - key_url: {{ repo.key_url }}
   {%- endif %}
+  - require:
+    - pkg: linux_packages
 
 {%- endif %}
 
@@ -80,6 +82,8 @@ linux_repo_{{ name }}:
   {%- if repo.gpgkey is defined %}
   - gpgkey: {{ repo.gpgkey }}
   {%- endif %}
+  - require:
+    - pkg: linux_packages
 
 {%- endif %}
 
@@ -99,6 +103,8 @@ default_repo_list:
     - mode: 0644
     - defaults:
         default_repos: {{ default_repos }}
+    - require:
+      - pkg: linux_packages
 
 {%- endif %}
 


### PR DESCRIPTION
When someone add https repository, the state will fail, becase it is not able to work without apt-transport-https which is installed in package state.