### PR TITLE
Feature: automatically set txqueuelen for all tap* network interfaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -771,6 +771,14 @@ Setup resolv.conf, nameservers, domain and search domains
           - timeout: 2
           - attempts: 2
 
+**setting custom TX queue length for tap interfaces**
+
+.. code-block:: yaml
+
+    linux:
+      network:
+        tap_custom_txqueuelen: 10000
+
 DPDK OVS interfaces
 --------------------
 

--- a/linux/files/60-net-txqueue.rules
+++ b/linux/files/60-net-txqueue.rules
@@ -1,0 +1,1 @@
+KERNEL==”tap[0-9a-z\-]*", RUN+="/sbin/ip link set %k txqueuelen {{ network.tap_custom_txqueuelen }}"

--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -285,3 +285,13 @@ NetworkManager:
   - enable: false
 
 {%- endif %}
+
+{%- if network.tap_custom_txqueuelen is defined %}
+
+/etc/udev/rules.d/60-net-txqueue.rules:
+  file.managed:
+  - source: salt://linux/files/60-net-txqueue.rules
+  - mode: 755
+  - template: jinja
+
+{%- endif %}


### PR DESCRIPTION
Config:

linux:
  network:
    tap_custom_txqueuelen: 10000

in case of configuration parameter defined will create file:

/etc/udev/rules.d/60-net-txqueue.rules

with content:

KERNEL==”tap[0-9a-z\-]*", RUN+="/sbin/ip link set %k txqueuelen 10000"