### PR TITLE
Update etc_environment

### DIFF
--- a/linux/files/etc_environment
+++ b/linux/files/etc_environment
@@ -11,22 +11,22 @@
 {%- endfor %}
 
 {%- if ftp_proxy and ftp_proxy.lower() != 'none' %}
-ftp_proxy="{{ ftp_proxy }}";
-FTP_PROXY="{{ ftp_proxy }}";
+ftp_proxy="{{ ftp_proxy }}"
+FTP_PROXY="{{ ftp_proxy }}"
 {%- endif %}
 
 {%- if http_proxy and http_proxy.lower() != 'none' %}
-http_proxy="{{ http_proxy }}";
-HTTP_PROXY="{{ http_proxy }}";
+http_proxy="{{ http_proxy }}"
+HTTP_PROXY="{{ http_proxy }}"
 {%- endif %}
 
 {%- if https_proxy and https_proxy.lower() != 'none' %}
-https_proxy="{{ https_proxy }}";
-HTTPS_PROXY="{{ https_proxy }}";
+https_proxy="{{ https_proxy }}"
+HTTPS_PROXY="{{ https_proxy }}"
 {%- endif %}
 
 {%- if no_proxy %}
-no_proxy="{{ no_proxy|join(',') }}";
-NO_PROXY="{{ no_proxy|join(',') }}";
+no_proxy="{{ no_proxy|join(',') }}"
+NO_PROXY="{{ no_proxy|join(',') }}"
 {%- endif %}
 


### PR DESCRIPTION
Need to remove useless semicolon because it is not working properly.
For example:
```
root@node:~# grep http_proxy /etc/environment
http_proxy="http://10.0.0.1:8080";
root@node:~# env | grep http_proxy
http_proxy=http://10.0.0.1:8080";
root@node:~# curl http://google.com
curl: (7) Failed to connect to 10.0.0.1 port 80: Connection refused
root@node:~# export http_proxy=http://10.0.0.1:8080
root@node:~# curl http://google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>302 Moved</TITLE></HEAD><BODY>
<H1>302 Moved</H1>
The document has moved
<A HREF="http://www.google.co.in/?gfe_rd=cr&amp;ei=e2XaWPTrIY6I8Qesn6PADA">here</A>.
</BODY></HTML>
```