### PR TITLE
remove require linux_packages on repo setup

### DIFF
--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -100,8 +100,9 @@ linux_repo_{{ name }}:
   - consolidate: {{ repo.get('consolidate', False) }}
   - clean_file: {{ repo.get('clean_file', False) }}
   - refresh_db: {{ repo.get('refresh_db', True) }}
+  {%- if repo.get('proxy', {}).get('enabled') or system.proxy.get('pkg', {}).get('enabled') %}
   - require:
-    - pkg: linux_packages
+  {%- endif %}
   {%- if repo.get('proxy', {}).get('enabled', False) %}
     - file: /etc/apt/apt.conf.d/99proxies-salt-{{ name }}
   {%- endif %}
@@ -135,8 +136,6 @@ linux_repo_{{ name }}:
   {%- if repo.gpgkey is defined %}
   - gpgkey: {{ repo.gpgkey }}
   {%- endif %}
-  - require:
-    - pkg: linux_packages
 
 {%- endif %}
 
@@ -156,8 +155,6 @@ default_repo_list:
     - mode: 0644
     - defaults:
         default_repos: {{ default_repos }}
-    - require:
-      - pkg: linux_packages
 
 {%- endif %}
 


### PR DESCRIPTION

Issue:
* On system with wrong repos OR env. with only local repos OR system with any repo (ie: sources.list removed)
* dependency packages can't be installed before linux.system.repo is run


Consequences, if for example:
* apt-transport-https, or python-apt is required before the repo is set, then we may try to force it, but should silently survive if such action fails. 

