### PR TITLE
RIL-267 Adding cpu governor and kernel module opts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,6 +317,20 @@ Load kernel modules and add them to `/etc/modules`:
             - tp_smapi
             - 8021q
 
+Configure kernel modules with additional options to `/etc/modprobe.d`
+following example will add `/etc/modprobe.d/nf_conntrack.conf` file
+with line `options nf_conntrack hashsize=262144`:
+
+.. code-block:: yaml
+
+    linux:
+      system:
+        kernel:
+          kmod_config:
+            nf_conntrack:
+              - "options nf_conntrack hashsize=262144"
+
+
 Install specific kernel version and ensure all other kernel packages are
 not present. Also install extra modules and headers for this kernel:
 
@@ -346,7 +360,7 @@ Systcl kernel parameters
 CPU
 ~~~
 
-Disable ondemand cpu mode service:
+Enable cpufreq governor for every cpu:
 
 .. code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -317,18 +317,19 @@ Load kernel modules and add them to `/etc/modules`:
             - tp_smapi
             - 8021q
 
-Configure kernel modules with additional options to `/etc/modprobe.d`
-following example will add `/etc/modprobe.d/nf_conntrack.conf` file
-with line `options nf_conntrack hashsize=262144`:
+Configure or blacklist kernel modules with additional options to `/etc/modprobe.d` following example 
+will add `/etc/modprobe.d/nf_conntrack.conf` file with line `options nf_conntrack hashsize=262144`:
 
 .. code-block:: yaml
 
     linux:
       system:
         kernel:
-          kmod_config:
+          module:
             nf_conntrack:
-              - "options nf_conntrack hashsize=262144"
+              option:
+                hashsize: 262144
+
 
 
 Install specific kernel version and ensure all other kernel packages are

--- a/linux/files/governor.conf.jinja
+++ b/linux/files/governor.conf.jinja
@@ -1,0 +1,3 @@
+{% for cpu_core in range(salt['grains.get']('num_cpus', 1)) %}
+devices/system/cpu/cpu{{ cpu_core }}/cpufreq/scaling_governor = {{ governor }}
+{% endfor %}

--- a/linux/files/modprobe.conf.jinja
+++ b/linux/files/modprobe.conf.jinja
@@ -1,0 +1,12 @@
+{% if module_content.disabled is defined and module_content.disabled -%}
+blacklist {{ module_name }}
+{%- else -%}
+
+{%- if module_content.option is defined -%}
+##### Module options #####
+{% for option, value in module_content.option | dictsort -%}
+options {{ module_name }} {{ option }}={{ value }}
+{%- endfor %}
+{%- endif -%}
+
+{%- endif %}

--- a/linux/files/modprobe.conf.jinja
+++ b/linux/files/modprobe.conf.jinja
@@ -1,12 +1,9 @@
-{% if module_content.disabled is defined and module_content.disabled -%}
+{% if module_content.get('blacklist', false) -%}
 blacklist {{ module_name }}
 {%- else -%}
 
-{%- if module_content.option is defined -%}
-##### Module options #####
-{% for option, value in module_content.option | dictsort -%}
+{%- for option, value in module_content.get('option', {}) | dictsort -%}
 options {{ module_name }} {{ option }}={{ value }}
 {%- endfor %}
-{%- endif -%}
 
 {%- endif %}

--- a/linux/system/cpu.sls
+++ b/linux/system/cpu.sls
@@ -1,9 +1,40 @@
 {%- from "linux/map.jinja" import system with context %}
 {%- if system.cpu.governor is defined %}
 
+linux_sysfs_package:
+  pkg.installed:
+    - pkgs:
+      - sysfsutils
+    - refresh: true
+
+/etc/sysfs.d:
+  file.directory:
+    - require:
+      - pkg: linux_sysfs_package
+
 ondemand_service_disable:
   service.dead:
-  - name: ondemand
-  - enable: false
+    - name: ondemand
+    - enable: false
+
+/etc/sysfs.d/governor.conf:
+  file.managed:
+    - source: salt://linux/files/governor.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 0644
+    - defaults:
+        governor: {{ system.cpu.governor }}
+
+{% for cpu_core in range(salt['grains.get']('num_cpus', 1)) %}
+
+governor_write_sysfs_cpu_core_{{ cpu_core }}:
+  module.run:
+    - name: sysfs.write
+    - key: devices/system/cpu/cpu{{ cpu_core }}/cpufreq/scaling_governor
+    - value: {{ system.cpu.governor }}
+
+{%- endfor %}
 
 {%- endif %}

--- a/linux/system/kernel.sls
+++ b/linux/system/kernel.sls
@@ -53,6 +53,17 @@ linux_kernel_module_{{ module }}:
 
 {%- endfor %}
 
+{%- for kmod_config, kmod_content in system.kernel.get('kmod_config', {}).iteritems() %}
+
+/etc/modprobe.d/{{ kmod_config }}.conf:
+  file.managed:
+    - contents:
+{%- for line in kmod_content %}
+      - {{ line }}
+{%- endfor %}
+
+{%- endfor %}
+
 {%- for sysctl_name, sysctl_value in system.kernel.get('sysctl', {}).iteritems() %}
 
 linux_kernel_{{ sysctl_name }}:

--- a/linux/system/kernel.sls
+++ b/linux/system/kernel.sls
@@ -53,14 +53,18 @@ linux_kernel_module_{{ module }}:
 
 {%- endfor %}
 
-{%- for kmod_config, kmod_content in system.kernel.get('kmod_config', {}).iteritems() %}
+{%- for module_name, module_content in system.kernel.get('module', {}).iteritems() %}
 
-/etc/modprobe.d/{{ kmod_config }}.conf:
+/etc/modprobe.d/{{ module_name }}.conf:
   file.managed:
-    - contents:
-{%- for line in kmod_content %}
-      - {{ line }}
-{%- endfor %}
+    - user: root
+    - group: root
+    - mode: 0644
+    - template: jinja
+    - source: salt://linux/files/modprobe.conf.jinja
+    - defaults:
+       module_content: {{ module_content }}
+       module_name: {{ module_name }}
 
 {%- endfor %}
 


### PR DESCRIPTION
This commit adds 2 features:
1. Add persistent cpu governor for every cpu core on;
2. Control /etc/modprobe.d/ directory to set any options that maybe required. 
  