### PR TITLE
change system state group/user order

### DIFF
--- a/linux/system/init.sls
+++ b/linux/system/init.sls
@@ -35,11 +35,11 @@ include:
 {%- if system.bash is defined %}
 - linux.system.bash
 {%- endif %}
-{%- if system.user|length > 0 %}
-- linux.system.user
-{%- endif %}
 {%- if system.group|length > 0 %}
 - linux.system.group
+{%- endif %}
+{%- if system.user|length > 0 %}
+- linux.system.user
 {%- endif %}
 {%- if system.rc is defined %}
 - linux.system.rc


### PR DESCRIPTION
we frequently finds state's not passing first time, as users are not added because group not exist.
may trigger opposite issue (as I quite believe group may require users that don't exist) as well.