### PR TITLE
Permit partition size to be monitored via raw bytes instead of disk percentage

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -207,8 +207,8 @@
         },
         'disk': {
               'use_raw_size': False,
-              'warn': '15%',
-              'crit': '5%',
+              'warn': '15',
+              'crit': '5',
         },
     },
 }, grain='os_family', merge=salt['pillar.get']('linux:monitoring')) %}

--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -206,6 +206,7 @@
               'crit': '20%',
         },
         'disk': {
+              'use_raw_size': False,
               'warn': '15%',
               'crit': '5%',
         },

--- a/linux/meta/heka.yml
+++ b/linux/meta/heka.yml
@@ -1,3 +1,4 @@
+{%- from "linux/map.jinja" import monitoring with context -%}
 metric_collector:
   trigger:
     linux_system_cpu_critical:
@@ -61,15 +62,20 @@ metric_collector:
         window: 60
         periods: 0
         function: avg
+{%- if monitoring.disk.use_raw_size %}
+{%- set disk_space_metric = 'fs_space_free' %}
+{%- else %}
+{%- set disk_space_metric = 'fs_space_percent_free' %}
+{%- endif %}
     linux_system_root_fs_warning:
       description: "The root filesystem's free space is low"
       severity: warning
       rules:
-      - metric: fs_space_percent_free
+      - metric: {{ disk_space_metric }}
         field:
           fs: '/'
         relational_operator: '<'
-        threshold: 10
+        threshold: {{ monitoring.disk.warn }}
         window: 60
         periods: 0
         function: min
@@ -77,11 +83,11 @@ metric_collector:
       description: "The root filesystem's free space is too low"
       severity: critical
       rules:
-      - metric: fs_space_percent_free
+      - metric: {{ disk_space_metric }}
         field:
           fs: '/'
         relational_operator: '<'
-        threshold: 5
+        threshold: {{ monitoring.disk.crit }}
         window: 60
         periods: 0
         function: min


### PR DESCRIPTION
Permit partition size to be monitored via raw bytes instead of disk used percentages which don't work very well with modern disk sizes.

Enable with:
  linux:
    monitoring:
      disk:
        use_raw_size: True
        warn: 21474836480 # 20 GB
        crit: 5368709120  # 5 GB