### PR TITLE
Adds ability to set mtu in reclass

### DIFF
--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -122,6 +122,9 @@ linux_interface_{{ interface_name }}:
   - enabled: {{ interface.enabled }}
   - name: {{ interface_name }}
   - type: {{ interface.type }}
+  {% if interface.mtu is defined %}
+  - mtu: {{ interface.mtu }}
+  {% endif %}
   {%- if interface.address is defined %}
   {%- if grains.os_family == 'Debian' %}
   - proto: {{ interface.get('proto', 'static') }}


### PR DESCRIPTION
Change of mtu is not handled by reclass. Example interface:
```
        br_ctl:
          enabled: true
          type: bridge
          proto: static
          mtu: 1450
          address: ${_param:single_address}
          gateway: ${_param:ctl_gateway}
          netmask: ${_param:control_network_netmask}
          use_interfaces:
          - ${_param:primary_first_nic}
```