### PR TITLE
[MMO-140] Add/ensure packages that are useful for troubleshooting

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -20,7 +20,7 @@
         'ca_certs_dir': '/usr/local/share/ca-certificates',
     },
     'Debian': {
-        'pkgs': ['python-apt', 'apt-transport-https', 'libmnl0'],
+        'pkgs': ['python-apt', 'apt-transport-https', 'libmnl0', 'mcelog', 'smartmontools', 'lsscsi', 'sysstat', 'strace', 'tcpdump', 'iputils-arping'],
         'utc': true,
         'user': {},
         'group': {},


### PR DESCRIPTION
Add/ensure packages that are useful for debugging and troubleshooting.  These should be installed by default.