### PR TITLE
sort mount points

### DIFF
--- a/linux/storage/mount.sls
+++ b/linux/storage/mount.sls
@@ -1,7 +1,7 @@
 {%- from "linux/map.jinja" import storage with context %}
 {%- if storage.enabled %}
 
-{%- for name, mount in storage.mount.iteritems() %}
+{%- for name, mount in storage.mount|dictsort %}
 
 {%- if mount.enabled %}
 


### PR DESCRIPTION
Usually you need define order for mounting volumes in one path like mount first /opt and then /opt/cms etc.