### PR TITLE
add startsector for partitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1437,7 +1437,7 @@ LVM group `vg1` with one device and `data` volume mounted into `/mnt/data`
                   mount: ${linux:storage:mount:data}
 
 Create partitions on disk. Specify size in MB. It expects empty
-disk without any existing partitions.
+disk without any existing partitions. (set startsector=1, if you want to start partitions from 2048)
 
 .. code-block:: yaml
 
@@ -1445,6 +1445,7 @@ disk without any existing partitions.
         storage:
           disk:
             first_drive:
+              startsector: 1
               name: /dev/loop1
               type: gpt
               partitions:

--- a/linux/storage/disk.sls
+++ b/linux/storage/disk.sls
@@ -20,6 +20,9 @@ create_disk_label_{{ disk_name }}:
     - pkg: parted
 
 {% set end_size = 0 -%}
+{% if disk.get('startsector', None) %}
+{% set end_size = disk.get('startsector')|int %}
+{% endif %}
 
 {%- for partition in disk.get('partitions', []) %}
 


### PR DESCRIPTION
Hi guys :)

I extend storage.disk pillar with another option, because I would like to start creating partiions on disk from some point, for example from 2048. 
Example:
 storage:
    enabled: true
    disk:
      /dev/sdb:
        startsector: 1      #Value in MB to start from sector 2048
        type: gpt
        partitions:
          - size: 256000    #Value in MB
            mkfs: True
            type: xfs

In environment where I use a lot of virtual machines, setting startsector give me small boost with using partition alligment.
http://www.blueshiftblog.com/?p=300
I add this change to salt-formula, and I think that will be good to share this with you :)

Would you like to add this option in seperate example in readme?
That's my first pull request in salt community, and I will be happy for your opinions and comments.


