### PR TITLE
Add elevator parameter to GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/linux/system/kernel.sls
+++ b/linux/system/kernel.sls
@@ -20,6 +20,23 @@ include:
 {%- endif %}
 {%- endif %}
 
+{%- if system.kernel.elevator is defined %}
+
+include:
+  - linux.system.grub
+
+/etc/default/grub.d/91-elevator.cfg:
+  file.managed:
+    - contents: 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT elevator={{ system.kernel.elevator }}"'
+    - require:
+      - file: grub_d_directory
+{%- if grains.get('virtual_subtype', None) not in ['Docker', 'LXC'] %}
+    - watch_in:
+      - cmd: grub_update
+
+{%- endif %}
+{%- endif %}
+
 {%- if system.kernel.version is defined %}
 
 linux_kernel_package:

--- a/tests/pillar/system.sls
+++ b/tests/pillar/system.sls
@@ -18,6 +18,7 @@ linux:
       default: "linux.ci.local$"
     kernel:
       isolcpu: 1,2,3,4
+      elevator: deadline
     sysfs:
       scheduler:
         block/sda/queue/scheduler: deadline


### PR DESCRIPTION
Adds elevator parameter to Linux Kernel command line to configure default queue scheduler at boot time.

One can already configure queue scheduler using linux.system.sysfs.scheduler, but has to define every block device separatly.