### PR TITLE
routes: Skip network restart on 'noifupdown'

### DIFF
--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -338,6 +338,9 @@ linux_network_{{ interface_name }}_routes:
       gateway: {{ route.gateway }}
       {%- endif %}
     {%- endfor %}
+  {%- if interface.noifupdown is defined %}
+  - require_reboot: {{ interface.noifupdown }}
+  {%- endif %}
 
 {%- endif %}
 


### PR DESCRIPTION
Previously, setting up routes did not allow passing 'require_reboot',
so each route change would lead to a networking service restart,
rendering interface configuration options like 'noifupdown' useless.
Allow disabling network restart per-interface using the existing
'noifupdown' option.

This caused me some issues with the following use-case:
1. node provisioned by MaaS, dhcp on eth0
2. trying to configure a bridge on top of eth0 (hence moving DHCP from eth0 to that bridge)
3. set all interfaces to 'noifupdown', planning to let the config kick in after a reboot
4. trying to configure a route on another interface at the same will restart the networking service, which obviously breaks;

Using 'noifupdown' seems like a good idea to me, but we can decouple them if needed ...