### PR TITLE
add additional shared libraries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,14 +424,14 @@ Enable cpufreq governor for every cpu:
 Shared Libraries
 ~~~~~~~~~~~~~~~~
 
-Set additional shared libraries to Linux system library path
+Set additional shared library to Linux system library path
 
 .. code-block:: yaml
 
     linux:
       system:
         ld:
-          libraries:
+          library:
             java:
               - /usr/lib/jvm/jre-openjdk/lib/amd64/server
               - /opt/java/jre/lib/amd64/server

--- a/README.rst
+++ b/README.rst
@@ -428,14 +428,14 @@ Set additional shared libraries to Linux system library path
 
 .. code-block:: yaml
 
-linux:
-  system:
-    ld:
-      libraries:
-        java:
-          - /usr/lib/jvm/jre-openjdk/lib/amd64/server
-          - /opt/java/jre/lib/amd64/server
-
+    linux:
+      system:
+        ld:
+          libraries:
+            java:
+              - /usr/lib/jvm/jre-openjdk/lib/amd64/server
+              - /opt/java/jre/lib/amd64/server
+    
 
 Certificates
 ~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -420,6 +420,23 @@ Enable cpufreq governor for every cpu:
         cpu:
           governor: performance
 
+
+Shared Libraries
+~~~~~~~~~~~~~~~~
+
+Set additional shared libraries to Linux system library path
+
+.. code-block:: yaml
+
+linux:
+  system:
+    ld:
+      libraries:
+        java:
+          - /usr/lib/jvm/jre-openjdk/lib/amd64/server
+          - /opt/java/jre/lib/amd64/server
+
+
 Certificates
 ~~~~~~~~~~~~
 

--- a/linux/system/init.sls
+++ b/linux/system/init.sls
@@ -99,6 +99,9 @@ include:
 {%- if system.directory is defined %}
 - linux.system.directory
 {%- endif %}
+{%- if system.ld is defined %}
+- linux.system.ld
+{%- endif %}
 {%- if system.apt is defined and grains.os_family == 'Debian' %}
 - linux.system.apt
 {%- endif %}

--- a/linux/system/ld.sls
+++ b/linux/system/ld.sls
@@ -2,14 +2,14 @@
 
 {%- if system.enabled %}
 
-{%- for key in system.ld.libraries %}
+{%- for key in system.ld.library %}
 /etc/ld.so.conf.d/{{ key }}.conf:
   file.managed:
     - user: root
     - group: root
     - mode: 644
     - contents: |
-          {% for val in system.ld.libraries[key] -%}
+          {% for val in system.ld.library[key] -%}
           {{ val }}
           {% endfor %}
     - watch_in:

--- a/linux/system/ld.sls
+++ b/linux/system/ld.sls
@@ -1,0 +1,23 @@
+{%- from "linux/map.jinja" import system with context %}
+
+{%- if system.enabled %}
+
+{%- for key in system.ld.libraries %}
+/etc/ld.so.conf.d/{{ key }}.conf:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - contents: |
+          {% for val in system.ld.libraries[key] -%}
+          {{ val }}
+          {% endfor %}
+    - watch_in:
+      - cmd: ldconfig_update
+{% endfor %}
+
+ldconfig_update:
+  cmd.wait:
+  - name: ldconfig
+
+{% endif %}


### PR DESCRIPTION
Hello,

this merge request gives the ability to add shared libraries without set LD_LIBRARY_PATH variable. In general there a multiple ways to add additional non standard library locations. But this seems to me the most common way to persist this change:

1. Generate file in /etc/ld.so.conf.d/
2. Update /etc/ld.so.cache with ldconfig command

**example pillars:** 
```
    linux:
      system:
        enabled: True
        ld:
          libraries:
            java:
              - /usr/lib/jvm/jre-openjdk/lib/amd64/server
              - /opt/java/jre/lib/amd64/server
```
