### PR TITLE
Fix file mode for file.managed state

### DIFF
--- a/linux/system/file.sls
+++ b/linux/system/file.sls
@@ -17,8 +17,8 @@
     - makedirs: {{ file.get('makedirs', 'True') }}
     - user: {{ file.get('user', 'root') }}
     - group: {{ file.get('group', 'root') }}
-    {%- if file.file_mode is defined %}
-    - file_mode: {{ file.file_mode }}
+    {%- if file.mode is defined %}
+    - mode: {{ file.mode }}
     {%- endif %}
     {%- if file.dir_mode is defined %}
     - dir_mode: {{ file.dir_mode }}


### PR DESCRIPTION
file.managed use "mode" option and not "file_mode" to configure the
perms of the managed file.
See: https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html#salt.states.file.managed