### PR TITLE
ovs-dpdk should work without system reboot

### DIFF
--- a/linux/network/dpdk.sls
+++ b/linux/network/dpdk.sls
@@ -9,6 +9,7 @@ linux_dpdk_pkgs:
 linux_dpdk_kernel_module:
   kmod.present:
   - name: {{ network.dpdk.driver }}
+  - persist: true
   - require:
     - pkg: linux_dpdk_pkgs
   - require_in:

--- a/linux/network/dpdk.sls
+++ b/linux/network/dpdk.sls
@@ -73,6 +73,15 @@ linux_network_dpdk_ovs_option_{{ option }}:
 
 {%- endfor %}
 
+openvswitch_dpdk_ovs_alternative:
+  alternatives.remove:
+  - name: ovs-vswitchd
+  - path: /usr/lib/openvswitch-switch/ovs-vswitchd
+  - require:
+    - pkg: openvswitch_dpdk_pkgs
+  - watch_in:
+    - service: service_openvswitch
+
 service_openvswitch:
   service.running:
   - name: openvswitch-switch

--- a/linux/system/hugepages.sls
+++ b/linux/system/hugepages.sls
@@ -29,6 +29,13 @@ hugepages_mount_{{ hugepages_type }}:
     - mkmnt: true
     - opts: mode=775,pagesize={{ hugepages.size }}
 
+# Make hugepages available right away with a temporary systctl write
+# This will be handled via krn args after reboot, so don't use `sysctl.present`
+hugepages_sysctl_vm_nr_hugepages:
+  cmd.run:
+    - name: "sysctl vm.nr_hugepages={{ hugepages.count }}"
+    - unless: "sysctl vm.nr_hugepages | grep -qE '{{ hugepages.count }}'"
+
 {%- endif %}
 
 {%- endfor %}


### PR DESCRIPTION
To get a working ovs-dpdk without forcing a system reboot, we need to:
- set hugepages number via sysctl, so we can use them right away;
- handle ovs-vswitchd alternative;
