### PR TITLE
Workaround for fetching repo keys via proxy.

### DIFF
--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -121,9 +121,6 @@ linux_repo_{{ name }}:
   {%- if repo.key_server is defined %}
   - keyserver: {{ repo.key_server }}
   {%- endif %}
-  {%- if repo.key_url is defined %}
-  - key_url: {{ repo.key_url }}
-  {%- endif %}
   - consolidate: {{ repo.get('consolidate', False) }}
   - clean_file: {{ repo.get('clean_file', False) }}
   - refresh_db: {{ repo.get('refresh_db', True) }}
@@ -139,6 +136,24 @@ linux_repo_{{ name }}:
     - file: purge_sources_list_d_repos
   {%- endif %}
   {%- endif %}
+
+{%- if repo.get('key') %}
+
+linux_repo_{{ name }}_key:
+  cmd.run:
+    - name: "echo '{{ repo.key }}' | apt-key add -"
+    - onchange:
+      - pkgrepo: linux_repo_{{ name }}
+
+{%- elif repo.key_url|default(False) %}
+
+linux_repo_{{ name }}_key:
+  cmd.run:
+    - name: "curl -s {{ repo.key_url }} | apt-key add -"
+    - onchange:
+      - pkgrepo: linux_repo_{{ name }}
+
+{%- endif %}
 
 {%- else %}
 

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -85,7 +85,8 @@ linux_repo_{{ name }}_pin:
 
 linux_repo_{{ name }}_key:
   cmd.wait:
-    - name: "echo '{{ repo.key }}' | apt-key add -"
+    - name: |
+        echo '{{ repo.key|indent(8, false) }}' | apt-key add -
     - watch:
       - file: default_repo_list
 
@@ -141,8 +142,10 @@ linux_repo_{{ name }}:
 
 linux_repo_{{ name }}_key:
   cmd.run:
-    - name: "echo '{{ repo.key }}' | apt-key add -"
-    - unless: "apt-key finger --with-colons | grep -qF $(echo '{{ repo.key }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
+    - name: |
+        echo '{{ repo.key|indent(8, false) }}' | apt-key add -
+    - unless: |
+        apt-key finger --with-colons | grep -qF $(echo '{{ repo.key|indent(8, false) }}' | gpg --with-fingerprint --with-colons | grep -E '^fpr')
     - require_in:
       - pkgrepo: linux_repo_{{ name }}
 

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -142,7 +142,8 @@ linux_repo_{{ name }}:
 linux_repo_{{ name }}_key:
   cmd.run:
     - name: "echo '{{ repo.key }}' | apt-key add -"
-    - onchange:
+    - unless: "apt-key finger --with-colons | grep -qF $(echo '{{ repo-key }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
+    - require_in:
       - pkgrepo: linux_repo_{{ name }}
 
 {%- elif repo.key_url|default(False) %}
@@ -150,7 +151,8 @@ linux_repo_{{ name }}_key:
 linux_repo_{{ name }}_key:
   cmd.run:
     - name: "curl -s {{ repo.key_url }} | apt-key add -"
-    - onchange:
+    - unless: "apt-key finger --with-colons | grep -qF $(curl -s {{ repo.key_url }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
+    - require_in:
       - pkgrepo: linux_repo_{{ name }}
 
 {%- endif %}

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -142,7 +142,7 @@ linux_repo_{{ name }}:
 linux_repo_{{ name }}_key:
   cmd.run:
     - name: "echo '{{ repo.key }}' | apt-key add -"
-    - unless: "apt-key finger --with-colons | grep -qF $(echo '{{ repo-key }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
+    - unless: "apt-key finger --with-colons | grep -qF $(echo '{{ repo.key }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
     - require_in:
       - pkgrepo: linux_repo_{{ name }}
 

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -85,7 +85,7 @@ linux_repo_{{ name }}_pin:
 
 linux_repo_{{ name }}_key:
   cmd.wait:
-    - name: echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -
+    - name: "echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -"
     - watch:
       - file: default_repo_list
 
@@ -141,8 +141,8 @@ linux_repo_{{ name }}:
 
 linux_repo_{{ name }}_key:
   cmd.run:
-    - name: echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -
-    - unless: apt-key finger --with-colons | grep -qF $(echo -e '{{ repo.key|replace('\n', '\\n') }}' | gpg --with-fingerprint --with-colons | grep -E '^fpr')
+    - name: "echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -"
+    - unless: "apt-key finger --with-colons | grep -qF $(echo -e '{{ repo.key|replace('\n', '\\n') }}' | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
     - require_in:
       - pkgrepo: linux_repo_{{ name }}
 

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -93,7 +93,7 @@ linux_repo_{{ name }}_key:
 
 linux_repo_{{ name }}_key:
   cmd.wait:
-    - name: "curl -s {{ repo.key_url }} | apt-key add -"
+    - name: "curl -sL {{ repo.key_url }} | apt-key add -"
     - watch:
       - file: default_repo_list
 
@@ -150,8 +150,8 @@ linux_repo_{{ name }}_key:
 
 linux_repo_{{ name }}_key:
   cmd.run:
-    - name: "curl -s {{ repo.key_url }} | apt-key add -"
-    - unless: "apt-key finger --with-colons | grep -qF $(curl -s {{ repo.key_url }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
+    - name: "curl -sL {{ repo.key_url }} | apt-key add -"
+    - unless: "apt-key finger --with-colons | grep -qF $(curl -sL {{ repo.key_url }} | gpg --with-fingerprint --with-colons | grep -E '^fpr')"
     - require_in:
       - pkgrepo: linux_repo_{{ name }}
 

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -85,8 +85,7 @@ linux_repo_{{ name }}_pin:
 
 linux_repo_{{ name }}_key:
   cmd.wait:
-    - name: |
-        echo '{{ repo.key|indent(8, false) }}' | apt-key add -
+    - name: echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -
     - watch:
       - file: default_repo_list
 
@@ -142,10 +141,8 @@ linux_repo_{{ name }}:
 
 linux_repo_{{ name }}_key:
   cmd.run:
-    - name: |
-        echo '{{ repo.key|indent(8, false) }}' | apt-key add -
-    - unless: |
-        apt-key finger --with-colons | grep -qF $(echo '{{ repo.key|indent(8, false) }}' | gpg --with-fingerprint --with-colons | grep -E '^fpr')
+    - name: echo -e '{{ repo.key|replace('\n', '\\n') }}' | apt-key add -
+    - unless: apt-key finger --with-colons | grep -qF $(echo -e '{{ repo.key|replace('\n', '\\n') }}' | gpg --with-fingerprint --with-colons | grep -E '^fpr')
     - require_in:
       - pkgrepo: linux_repo_{{ name }}
 


### PR DESCRIPTION
Salt has problem to fetch repo key from behind proxy with this simple state:
```
pkgrepo.managed:
- key_url: some_url
```
This workaround enables adding repo and fetch it's gpg key from behind proxy, if proxy environment is properly configured (`curl -s some_url` works).