### PR TITLE
Disable module module from loading.

### DIFF
--- a/linux/files/modprobe.conf.jinja
+++ b/linux/files/modprobe.conf.jinja
@@ -1,5 +1,8 @@
 {% if module_content.get('blacklist', false) -%}
 blacklist {{ module_name }}
+
+{% elif module_content.get('disabled', false) -%}
+install {{ module_name }} /bin/true
 {%- else -%}
 
 options {{ module_name }}{% for option, value in module_content.get('option', {}) | dictsort %} {{ option }}={{ value }}{% endfor %}


### PR DESCRIPTION
Blacklist only stop a module from being loaded at boot, but several CIS controls require that modules be blocked from being load completely. I propose the feature be added to disable the module from being loaded completely.