### PR TITLE
Create user home parent dir if makedirs is True

### DIFF
--- a/linux/system/user.sls
+++ b/linux/system/user.sls
@@ -23,6 +23,15 @@ system_group_{{ name }}:
     - user: system_user_{{ name }}
 {%- endif %}
 
+{%- if user.get('makedirs') %}
+system_user_home_parentdir_{{ user.home }}:
+  file.directory:
+  - name: {{ user.home | path_join("..") }}
+  - makedirs: true
+  - require_in:
+    - user: system_user_{{ name }}
+{%- endif %}
+
 system_user_{{ name }}:
   user.present:
   - name: {{ name }}


### PR DESCRIPTION
So that the state won't fail if the parent directory of the home directory does not exist.