### PR TITLE
change logic when I define user.gid

### DIFF
--- a/linux/system/user.sls
+++ b/linux/system/user.sls
@@ -37,7 +37,11 @@ system_user_{{ name }}:
   - password: {{ user.password }}
   - hash_password: {{ user.get('hash_password', False) }}
   {% endif %}
+  {%- if user.gid is defined and user.gid %}
+  - gid: {{ user.gid }}
+  {%- else %}
   - gid_from_name: true
+  {%- endif %}
   {%- if user.groups is defined %}
   - groups: {{ user.groups }}
   {%- endif %}


### PR DESCRIPTION
When I define user.gid I don't expecting that "default" group will have same name as name of user, so the option "gid_from_name: true" is unnecessary.