### PR TITLE
Match server hostname in Open_vSwitch table

### DIFF
--- a/linux/files/openvswitch-switch.systemd
+++ b/linux/files/openvswitch-switch.systemd
@@ -1,0 +1,18 @@
+[Unit]
+Description=Open vSwitch
+Before=network.target
+After=network-pre.target ovsdb-server.service ovs-vswitchd.service
+PartOf=network.target
+Requires=ovsdb-server.service
+Requires=ovs-vswitchd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set open . external-ids:hostname=%H
+ExecReload=/bin/true
+ExecStop=/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/linux/network/openvswitch.sls
+++ b/linux/network/openvswitch.sls
@@ -13,6 +13,17 @@ openvswitch_pkgs:
     - require:
       - pkg: openvswitch_pkgs
 
+/etc/systemd/system/openvswitch-switch.service:
+  file.managed:
+    - source: salt://linux/files/openvswitch-switch.systemd
+    - template: jinja
+    - require:
+      - pkg: openvswitch_pkgs
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/openvswitch-switch.service
+
 openvswitch_switch_service:
   service.running:
     - name: openvswitch-switch


### PR DESCRIPTION
This workaround is necessary in case of OVN networking in Openstack. Usually hostname of a server is in short form, but in Ovs table Open_vSwitch is always presented fqdn name. This mismatch prevent neutron to set "requested-chassis" in OVN. The mismatch in hypervisor's external-ids:hostname setting
causes OVN port binding failure.
This extension of state allow set same hostname in ovs at time of starting according to server hostname.

More info bellow. This ovs patch solve the problem, but in new releases of Openvswitch:
https://patchwork.ozlabs.org/patch/979143/