### PR TITLE
Fix for issue #179. In linux/system/profile.sls, profile scripts alwa…

### DIFF
--- a/linux/system/profile.sls
+++ b/linux/system/profile.sls
@@ -20,7 +20,7 @@ profile.d_script_{{ name  }}:
     - defaults:
           script: {{ script|yaml }}
     - require_in:
-      - service: profile.d_clean
+      - file: profile.d_clean
 {% endfor %}
 
 {%- endif %}


### PR DESCRIPTION
…ys recreated. We need to define file instead service in required_in.

This is fix for issue #179 and prevent profile scripts to be recreated if not necessary.