### PR TITLE
Add SELinux to README and test pillars (/linux/system/selinux.sls).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -717,6 +717,16 @@ Enable cpufreq governor for every cpu:
         cpu:
           governor: performance
 
+SELinux
+~~~~~~~
+
+Set SELinux mode on System:
+
+.. code-block:: yaml
+
+    linux:
+      system:
+        selinux: permissive
 
 CGROUPS
 ~~~~~~~

--- a/tests/pillar/system.sls
+++ b/tests/pillar/system.sls
@@ -24,6 +24,7 @@ linux:
     domain: ci.local
     environment: prd
     purge_repos: true
+    selinux: permissive
     directory:
       /tmp/test:
         makedirs: true


### PR DESCRIPTION
Hi,

right now selinux in system is not in README and not in test pillars defined. This commit will add it to Readme and add it to test pillars.