### PR TITLE
This is fix for #182 - Dependency problem in linux/system/selinux.sls.

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -15,8 +15,11 @@
         'package': {},
         'autoupdates': {
           'pkgs': []
-         },
-        'selinux': 'permissive',
+        },
+        'selinux': {
+             'pkgs': [],
+             'mode': 'permissive',
+        },
         'ca_certs_dir': '/usr/local/share/ca-certificates',
         'ca_certs_bin': 'update-ca-certificates',
         'atop': {
@@ -25,7 +28,7 @@
              'autostart': true,
              'logpath': '/var/log/atop',
              'outfile': '/var/log/atop/daily.log'
-         },
+        },
         'at': {
              'pkgs': [],
              'services': []
@@ -52,7 +55,10 @@
         'autoupdates': {
              'pkgs': ['unattended-upgrades']
          },
-        'selinux': 'permissive',
+        'selinux': {
+             'pkgs': [],
+             'mode': 'permissive',
+        },
         'ca_certs_dir': '/usr/local/share/ca-certificates',
         'ca_certs_bin': 'update-ca-certificates',
         'atop': {
@@ -90,7 +96,10 @@
         'autoupdates': {
              'pkgs': []
          },
-        'selinux': 'permissive',
+        'selinux': {
+             'pkgs': ['policycoreutils','policycoreutils-python'],
+             'mode': 'permissive',
+        },
         'ca_certs_dir': '/etc/pki/ca-trust/source/anchors',
         'ca_certs_bin': 'update-ca-trust extract',
         'atop': {
@@ -381,6 +390,7 @@ Debian:
              'pkgs': [],
              'service': 'multipath'
          },
+        'lvm_pkgs': ['lvm2'],
     },
 }, merge=salt['grains.filter_by']({
     'trusty': {

--- a/linux/system/selinux.sls
+++ b/linux/system/selinux.sls
@@ -1,18 +1,19 @@
 {%- from "linux/map.jinja" import system with context %}
 {%- if system.selinux is defined %}
 
-include:
-- linux.system.repo
+  {% if system.selinux.pkgs %}
+linux_system_selinux_pkgs:
+  pkg.installed:
+  - pkgs: {{ system.selinux.pkgs }}
+  {%- endif %}
 
-{%- if grains.os_family == 'RedHat' %}
-  {%- set mode = system.selinux %}
+  {%- if grains.os_family == 'RedHat' %}
 
-{{ mode }}:
+{{ system.selinux.mode }}:
   selinux.mode:
     - require:
-      - pkg: linux_repo_prereq_pkgs
+      - pkg: linux_system_selinux_pkgs
 
-{%- endif %}
-
+  {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
- This change will remove dependecy from linux/system/repo.sls in linux/system/selinux.sls.
- It also change structure from pillars selinux

old:
linux:
  system:
    ...
    selinux: permissive

new:
linux:
  system:
    ...
    selinux:
      pkgs: ['policycoreutils', 'policycoreutils-python'],
      mode: permissive