### PR TITLE
added persistent cfg for native ovn bond

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1471,6 +1471,7 @@ Open vSwitch Bridges:
             enabled: true
             name: br-ens7
             type: ovs_bridge
+            ovs_ports: ens7
             proto: manual
             mtu: 9000
             use_interfaces:

--- a/linux/files/ovs_bridge
+++ b/linux/files/ovs_bridge
@@ -9,6 +9,10 @@ netmask {{ bridge.netmask }}
 {%- if bridge.gateway is defined %}
 gateway {{ bridge.gateway }}
 {%- endif %}
+{%- if bridge.ovs_ports is defined %}
+ovs_ports {{ bridge.ovs_ports }}
+{%- endif %}
 {%- if bridge.ovs_options is defined %}
 ovs_options {{ bridge.ovs_options }}
 {%- endif %}
+

--- a/linux/files/ovs_port
+++ b/linux/files/ovs_port
@@ -11,6 +11,10 @@ netmask {{ port.netmask }}
 {%- if port.gateway is defined %}
 gateway {{ port.gateway }}
 {%- endif %}
+{%- if port.slaves is defined %}
+ovs_bonds {{ port.slaves }}
+{%- endif %}
 {%- if port.ovs_options is defined %}
 ovs_options {{ port.ovs_options }}
 {%- endif %}
+

--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -152,7 +152,7 @@ linux_interfaces_include_{{ interface_name }}:
       source /etc/network/interfaces.u/*
 
 ovs_bridge_{{ interface_name }}:
-  file.managed:
+  file.append:
   - name: /etc/network/interfaces.u/ifcfg-{{ interface_name }}
   - makedirs: True
   - source: salt://linux/files/ovs_bridge
@@ -175,6 +175,18 @@ ovs_bond_{{ interface_name }}:
     - unless: ovs-vsctl show | grep -A 2 'Port.*{{ interface_name }}.'
     - require: 
       - ovs_bridge_{{ interface.bridge }}_present
+
+ovs_bond_persistent_{{ interface_name }}:
+  file.append:
+    - name: /etc/network/interfaces.u/ifcfg-{{ interface.bridge }}
+    - makedirs: True
+    - source: salt://linux/files/ovs_port
+    - template: jinja
+    - context:
+        port_name: {{ interface_name }}
+        port: {{ interface|yaml }}
+    - require:
+      - ovs_bridge_{{ interface.bridge }}
 
 {%- elif interface.type == 'ovs_port' %}
 

--- a/tests/pillar/network_openvswitch.sls
+++ b/tests/pillar/network_openvswitch.sls
@@ -18,6 +18,7 @@ linux:
         enabled: true
         type: ovs_bridge
         proto: manual
+        ovs_ports: ens0
         mtu: 9000
         use_interfaces:
         - ens0


### PR DESCRIPTION
This adds configuration for native ovs bond into network config. file/s in Ubuntu. Due to ovs bond belongs into given ovs bridge is necessary to bring up the bridge first and then add bond. This is why bond config is below of bridge in cfg file by file.append method.