### PR TITLE
Extend linux.storage.mount state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1971,6 +1971,33 @@ DPDK OVS interfaces
             address: ${_param:tenant_address}
             netmask: ${_param:tenant_network_netmask}
 
+**Linux Network Interface configuration**
+
+Configuration of network interface eth0 on RedHad.
+Parameter ipv6addrs used to bind ipv6 aliases to the network interface.
+
+.. code-block:: yaml
+
+    linux:
+      network:
+        ...
+        interface:
+          eth0:
+            enabled: true
+            type: eth
+            address: 192.168.0.1
+            netmask: 255.255.255.0
+            gateway: 192.168.0.154
+            name_servers:
+              - 192.168.0.10
+              - 192.168.0.11
+            ipv6_address: fd8f:a45a:2ed2:d37c::7
+            ipv6_netmask: 64
+            ipv6_gateway: fd8f:a45a:2ed2:d37c::1
+            ipv6addrs:
+              - fd8f:a45a:2ed2:d37c:ffff:fffe/128
+              - fd8f:a45a:2ed2:d37c:ffff:ffff/128
+
 **DPDK OVS bridge for VXLAN**
 
 If VXLAN is used as tenant segmentation, IP address must

--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -314,6 +314,9 @@ linux_interface_{{ interface_name }}:
   - slaves: {{ interface.slaves }}
   - mode: {{ interface.mode }}
   {%- endif %}
+  {%- if interface.ipv6addrs is defined %}
+  - ipv6addrs: {{ interface.ipv6addrs }}
+  {%- endif %}
 
 
 {%- if salt['grains.get']('saltversion') < '2017.7' %}

--- a/linux/storage/mount.sls
+++ b/linux/storage/mount.sls
@@ -41,6 +41,7 @@ linux_storage_nfs_packages:
   - fstype: {{ mount.file_system }}
   - mkmnt: True
   - opts: {{ mount.get('opts', 'defaults,noatime') }}
+  - mount: {{ mount.get('mount', 'True') }}
   {%- if mount.file_system == 'xfs' %}
   - require:
     - pkg: xfs_packages_{{ mount.device }}

--- a/linux/storage/mount.sls
+++ b/linux/storage/mount.sls
@@ -7,6 +7,7 @@
 
 {%- if not mount.file_system in ['nfs', 'nfs4', 'cifs', 'tmpfs'] %}
 
+{%- if mount.make_fs is defined and mount.make_fs %}
 mkfs_{{ mount.device}}:
   cmd.run:
   - name: "mkfs.{{ mount.file_system }} -L {{ name }} {{ mount.device }}"
@@ -16,11 +17,14 @@ mkfs_{{ mount.device}}:
   {%- if mount.file_system == 'xfs' %}
   - require:
     - pkg: xfs_packages_{{ mount.device }}
+  {%- endif %}
+{%- endif %}
 
+{%- if mount.file_system == 'xfs' %}
 xfs_packages_{{ mount.device }}:
   pkg.installed:
     - name: xfsprogs
-  {%- endif %}
+{% endif %}
 
 {%- endif %}
 

--- a/linux/storage/mount.sls
+++ b/linux/storage/mount.sls
@@ -42,6 +42,7 @@ linux_storage_nfs_packages:
   - mkmnt: True
   - opts: {{ mount.get('opts', 'defaults,noatime') }}
   - mount: {{ mount.get('mount', 'True') }}
+  - persist: {{ mount.get('save_to_fstab', 'False') }}
   {%- if mount.file_system == 'xfs' %}
   - require:
     - pkg: xfs_packages_{{ mount.device }}


### PR DESCRIPTION
Add 3 new feature:
1. Add option enable/disable force make XFS during mount. Currently makes enabled by default. No in all cases need force makers during mount procedure.
2. Add option that allow to save mount options to the stab file.
3. Add option that will allow do not mount device after add mount options to the stab file. Not in all cases need force mount. In some cases need configure disk in fstab and mount disk with manual control.