### PR TITLE
Add verification that directory pillar is not empty

### DIFF
--- a/linux/system/directory.sls
+++ b/linux/system/directory.sls
@@ -1,5 +1,6 @@
 {%- from "linux/map.jinja" import system with context %}
 
+{%- if system.directory is defined %}
 {%- for name, dir in system.directory.items() %}
 
 {{ dir.name|default(name) }}:
@@ -13,3 +14,4 @@
     {%- endif %}
 
 {%- endfor %}
+{% endif %}


### PR DESCRIPTION
Update will prevent errors if state is defined but not defined directory pillar.

If directory pillar is not defined customers will receive such errors:
`Rendering SLS 'base:linux.system.directory' failed: Jinja variable 'dict object' has no attribute 'directory'`