### PR TITLE
Add journal settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,18 +26,20 @@ install:
   - bundle install
 
 env:
-  - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2016.3 SUITE=network
-  - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2016.3 SUITE=system
   - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2017.7 SUITE=network
   - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2017.7 SUITE=system
   - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2018.3 SUITE=network
   - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2018.3 SUITE=system
   - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2018.3 SUITE=duo
+  - PLATFORM=netmanagers/salt-2019.2-py3:ubuntu-18.04 SUITE=network
+  # - PLATFORM=netmanagers/salt-2019.2-py3:ubuntu-18.04 SUITE=system
+  # - PLATFORM=netmanagers/salt-2019.2-py3:ubuntu-18.04 SUITE=duo 
   # - PLATFORM=epcim/salt:saltstack-ubuntu-bionic-salt-2017.7 SUITE=network
   # - PLATFORM=epcim/salt:saltstack-ubuntu-bionic-salt-2017.7 SUITE=system
   # - PLATFORM=epcim/salt:saltstack-ubuntu-bionic-salt-2018.3 SUITE=network
   # - PLATFORM=epcim/salt:saltstack-ubuntu-bionic-salt-2018.3 SUITE=system
-
+  # - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2016.3 SUITE=system
+  # - PLATFORM=epcim/salt:saltstack-ubuntu-xenial-salt-2016.3 SUITE=network
 before_script:
   - set -o pipefail
   - make test | tail

--- a/README.rst
+++ b/README.rst
@@ -430,6 +430,18 @@ Systemd settings:
               DefaultLimitCPU: 2
               DefaultLimitNPROC: 4
 
+Systemd journal settings:
+
+.. code-block:: yaml
+
+    linux:
+      system:
+        ...
+        systemd:
+          journal:
+            SystemMaxUse: "50M"
+            RuntimeMaxFiles: "100"
+            
 Ensure presence of directory:
 
 .. code-block:: yaml

--- a/linux/files/journal.conf
+++ b/linux/files/journal.conf
@@ -1,0 +1,6 @@
+{%- from "linux/map.jinja" import system with context -%}
+#This file is managed by salt
+[Journal]
+{%- for option, value in settings.items() %}
+{{ option }}={{ value }}
+{%- endfor -%}

--- a/linux/system/auth/duo.sls
+++ b/linux/system/auth/duo.sls
@@ -3,6 +3,8 @@
 package_duo:
   pkg.installed:
     - name: duo-unix
+    - skip_verify: True
+
 
 login_duo:
   file.managed:

--- a/linux/system/journal.sls
+++ b/linux/system/journal.sls
@@ -3,14 +3,14 @@
 
 {%- if system.systemd.journal is defined %}
 
-linux_systemd_system_config:
+linux_systemd_journal_config:
   file.managed:
     - name: /etc/systemd/journald.conf.d/90-salt.conf
     - source: salt://linux/files/journal.conf
     - template: jinja
     - makedirs: True
     - defaults:
-        settings: {{ system.systemd.journal }}
+        settings: {{ system.systemd.journal|tojson }}
     - watch_in:
       - module: linux_journal_systemd_reload
 

--- a/linux/system/journal.sls
+++ b/linux/system/journal.sls
@@ -1,0 +1,25 @@
+{%- from "linux/map.jinja" import system with context %}
+{%- if system.enabled and grains.get('init', None) == 'systemd' %}
+
+{%- if system.systemd.journal is defined %}
+
+linux_systemd_system_config:
+  file.managed:
+    - name: /etc/systemd/journald.conf.d/90-salt.conf
+    - source: salt://linux/files/journal.conf
+    - template: jinja
+    - makedirs: True
+    - defaults:
+        settings: {{ system.systemd.journal }}
+    - watch_in:
+      - module: linux_journal_systemd_reload
+
+linux_journal_systemd_reload:
+  module.wait:
+    - name: service.restart
+    - m_name: systemd-journald
+    - require:
+      - module: service.systemctl_reload
+
+{%- endif %}
+{%- endif %}

--- a/linux/system/systemd.sls
+++ b/linux/system/systemd.sls
@@ -1,5 +1,9 @@
 {%- from "linux/map.jinja" import system with context %}
 {%- if system.enabled and grains.get('init', None) == 'systemd' %}
+{%- if system.systemd.journal is defined %}
+include: 
+  - linux.system.journal
+{%- endif %}
 
 {%- if system.systemd.system is defined %}
 linux_systemd_system_config:

--- a/tests/pillar/system.sls
+++ b/tests/pillar/system.sls
@@ -458,7 +458,6 @@ linux:
         - host1
         - host2
         - .local
-
     # pillars for netconsole setup
     netconsole:
       enabled: true


### PR DESCRIPTION
This settings theoretically maybe could be added to systemd main settings, but documentation (https://www.freedesktop.org/software/systemd/man/journald.conf.html) says it should be in one of:
/etc/systemd/journald.conf
/etc/systemd/journald.conf.d/*.conf
/run/systemd/journald.conf.d/*.conf
/usr/lib/systemd/journald.conf.d/*.conf

no tests were added as dockers doesn't have systemd :(

