### PR TITLE
Create @reboot .... Cron jobs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,6 +327,21 @@ identifier same as command resulting in not being able to change it):
             hour: 2
             minute: 0
 
+Added the opportunity to set a job with a special keyword like '@reboot' or '@hourly'. Quotes must be used, otherwise PyYAML will strip the '@' sign.
+.. code-block:: yaml
+
+    linux:
+      system:
+        ...
+        job:
+          cmd1:
+            command: '/cmd/to/run'
+            identifier: cmd1
+            enabled: true
+            user: 'root'
+            special: '@reboot'
+
+
 Managing 'at' tasks
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -328,6 +328,7 @@ identifier same as command resulting in not being able to change it):
             minute: 0
 
 Added the opportunity to set a job with a special keyword like '@reboot' or '@hourly'. Quotes must be used, otherwise PyYAML will strip the '@' sign.
+
 .. code-block:: yaml
 
     linux:

--- a/linux/system/file.sls
+++ b/linux/system/file.sls
@@ -50,7 +50,10 @@ linux_file_{{ file_name }}:
     {%- if file.encoding is defined %}
     - encoding: {{ file.encoding }}
     {%- endif %}
-
+    {%- if file.replace is defined %}
+    - replace: {{ file.replace }}
+    {%- endif %}
+ 
 {%- endfor %}
 
 {%- endif %}

--- a/linux/system/file.sls
+++ b/linux/system/file.sls
@@ -39,6 +39,7 @@ linux_file_{{ file_name }}:
     - name: {{ file_name }}
     {%- endif %}
     - makedirs: {{ file.get('makedirs', 'True') }}
+    - replace: {{ file.get('replace', 'True') }}
     - user: {{ file.get('user', 'root') }}
     - group: {{ file.get('group', 'root') }}
     {%- if file.mode is defined %}
@@ -49,9 +50,6 @@ linux_file_{{ file_name }}:
     {%- endif %}
     {%- if file.encoding is defined %}
     - encoding: {{ file.encoding }}
-    {%- endif %}
-    {%- if file.replace is defined %}
-    - replace: {{ file.replace }}
     {%- endif %}
  
 {%- endfor %}

--- a/linux/system/job.sls
+++ b/linux/system/job.sls
@@ -17,20 +17,24 @@ linux_job_{{ job.command }}:
     - identifier: {{ job.get('identifier', job.get('name', name)) }}
       {%- endif %}
     - user: {{ job_user }}
-      {%- if job.minute is defined %}
+      {%- if job.special is defined %}
+    - special: '{{ job.special }}'
+      {%- else %}
+        {%- if job.minute is defined %}
     - minute: '{{ job.minute }}'
-      {%- endif %}
-      {%- if job.hour is defined %}
+        {%- endif %}
+        {%- if job.hour is defined %}
     - hour: '{{ job.hour }}'
-      {%- endif %}
-      {%- if job.daymonth is defined %}
+        {%- endif %}
+        {%- if job.daymonth is defined %}
     - daymonth: '{{ job.daymonth }}'
-      {%- endif %}
-      {%- if job.month is defined %}
+        {%- endif %}
+        {%- if job.month is defined %}
     - month: '{{ job.month }}'
       {%- endif %}
-      {%- if job.dayweek is defined %}
+        {%- if job.dayweek is defined %}
     - dayweek: '{{ job.dayweek }}'
+        {%- endif %}
       {%- endif %}
     - require:
       - sls: linux.system.cron


### PR DESCRIPTION
Added the opportunity to set a job with a special keyword like '@reboot' or '@hourly'. Quotes must be used, otherwise PyYAML will strip the '@' sign.

/path/to/cron/script:
  cron.present:
    - user: root
    - special: '@hourly'

https://docs.saltstack.com/en/master/ref/states/all/salt.states.cron.html
