### PR TITLE
fix(deprecation): update to new method

### DIFF
--- a/_modules/ovs_config.py
+++ b/_modules/ovs_config.py
@@ -6,7 +6,7 @@ Support for Open vSwitch database configuration.
 from __future__ import absolute_import
 
 import logging
-import salt.utils
+import salt.utils.path
 
 log = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def __virtual__():
     '''
     Only load the module if Open vSwitch is installed
     '''
-    if salt.utils.which('ovs-vsctl'):
+    if salt.utils.path.which('ovs-vsctl'):
         return 'ovs_config'
     return False
 


### PR DESCRIPTION
Should solve this warning:
```
[WARNING ] /var/cache/salt/minion/extmods/modules/ovs_config.py:18: DeprecationWarning: Use of 'salt.utils.which' detected. This function has been moved to 'salt.utils.path.which' as of Salt 2018.3.0. This warning will be removed in Salt Neon.
```