### PR TITLE
allow use of new state syntax for module.run

### DIFF
--- a/linux/network/host.sls
+++ b/linux/network/host.sls
@@ -70,10 +70,17 @@ linux_host_{{ name }}:
 
 linux_host_{{ name }}_order_fix:
   module.run:
+{%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - file.replace:
+      - path: /etc/hosts
+      - pattern: {{ before }}
+      - repl: {{ after }}
+{%- else %}
     - name: file.replace
     - path: /etc/hosts
     - pattern: {{ before }}
     - repl: {{ after }}
+{%- endif %}
     - watch:
       - host: linux_host_{{ name }}
     - onlyif:

--- a/linux/network/openvswitch.sls
+++ b/linux/network/openvswitch.sls
@@ -19,8 +19,14 @@ openvswitch_pkgs:
     - template: jinja
     - require:
       - pkg: openvswitch_pkgs
+
+openvswitch_sytemctl_reload:
   module.run:
+{%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - service.systemctl_reload: []
+{%- else %}
     - name: service.systemctl_reload
+{%- endif %}
     - onchanges:
       - file: /etc/systemd/system/openvswitch-switch.service
 

--- a/linux/storage/swap.sls
+++ b/linux/storage/swap.sls
@@ -59,9 +59,15 @@ linux_set_swap_file_status_{{ swap.device }}:
 
 {{ swap.device }}:
   module.run:
+  {%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - mount.rm_fstab:
+      - m_name: none
+      - device: {{ swap.device }}
+  {%- else %}
     - name: mount.rm_fstab
     - m_name: none
     - device: {{ swap.device }}
+  {%- endif %}
     - onlyif: grep -q {{ swap.device }} /etc/fstab
 
 linux_disable_swap_{{ swap.engine }}_{{ swap.device }}:

--- a/linux/system/cpu.sls
+++ b/linux/system/cpu.sls
@@ -30,9 +30,15 @@ ondemand_service_disable:
 {% if salt['file.file_exists']('/sys/'+ core_key) %}
 governor_write_sysfs_cpu_core_{{ cpu_core }}:
   module.run:
+  {%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - sysfs.write:
+      - key: {{ core_key }}
+      - value: {{ system.cpu.governor }}
+  {%- else %}
     - name: sysfs.write
     - key: {{ core_key }}
     - value: {{ system.cpu.governor }}
+  {%- endif %}
 {% endif %}
 
 {%- endfor %}

--- a/linux/system/repo.sls
+++ b/linux/system/repo.sls
@@ -223,7 +223,11 @@ default_repo_list:
 refresh_db:
   {%- if system.get('refresh_repos_meta', True) %}
   module.run:
+    {%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - pkg.refresh_db: []
+    {%- else %}
     - name: pkg.refresh_db
+    {% endif %}
   {%- else %}
   test.succeed_without_changes
   {%- endif %}

--- a/linux/system/sysfs.sls
+++ b/linux/system/sysfs.sls
@@ -44,9 +44,15 @@ linux_sysfs_package:
       {#- Sysfs cannot be set in docker, LXC, etc. #}
 linux_sysfs_write_{{ list_idx }}_{{ name }}_{{ key }}:
   module.run:
+        {%- if 'module.run' in salt['config.get']('use_superseded', default=[]) %}
+    - sysfs.write:
+      - key: {{ key }}
+      - value: {{ value }}
+        {%- else %}
     - name: sysfs.write
     - key: {{ key }}
     - value: {{ value }}
+        {%- endif %}
       {%- endif %}
     {%- endif %}
   {%- endfor %}


### PR DESCRIPTION
The new syntax has been supported since ~2017.
From the docs, in case they change:

! New Style
test.random_hash:
  module.run:
    - test.random_hash:
      - size: 42
      - hash_type: sha256

! Legacy Style
test.random_hash:
  module.run:
    - size: 42
    - hash_type: sha256