### PR TITLE
Idempotent clean dependency

### DIFF
--- a/linux/system/motd.sls
+++ b/linux/system/motd.sls
@@ -25,6 +25,10 @@ motd_fix_pam_sshd:
 /etc/motd:
   file.absent
 
+exist_/etc/update-motd.d:
+  file.directory:
+    - name: /etc/update-motd.d
+
 {%- for motd in system.motd %}
 {%- set motd_index = loop.index %}
 
@@ -35,8 +39,10 @@ motd_{{ motd_index }}_{{ name }}:
     - source: salt://linux/files/motd.sh
     - template: jinja
     - mode: 755
-    - require:
+    - require_in:
       - file: /etc/update-motd.d
+    - require:
+      - file: exist_/etc/update-motd.d
     - defaults:
         index: {{ motd_index }}
         motd_name: {{ name }}


### PR DESCRIPTION
For linux/system/motd.sls had a issue which, for multiple files, at every run both the cleaning (under "/etc/update-motd.d:") as well as every single file setup was triggered.

This commit solved the issue putting each managed file into the requirements of "/etc/update-motd.d:", this way it will not be deleted.
Hence again the /etc/update-motd.d has to be duplicated without "clean" parameter in order to have the dependency from the parent folder to its children files.