### PR TITLE
fix lvm_service package names for debian 11,12 and unstable

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -396,6 +396,15 @@ Debian:
     'buster': {
         'lvm_services': ['lvm2-monitor'],
     },
+    'bullseye': {
+        'lvm_services': ['lvm2-monitor'],
+    },
+    'bookworm': {
+        'lvm_services': ['lvm2-monitor'],
+    },
+    'sid': {
+        'lvm_services': ['lvm2-monitor'],
+    },
     'trusty': {
         'lvm_services': ['udev'],
     },


### PR DESCRIPTION
LVM services fail in debian-11. 
This PR adds lvm-services for bullseye, bookworm, and sid (similar to #207)