### PR TITLE
fix system-pkgs for debian-12

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -113,6 +113,9 @@
     'bullseye': {
         'pkgs': ['python3-apt', 'apt-transport-https', 'libmnl0'],
     },
+    'bookworm': {
+        'pkgs': ['python3-apt', 'apt-transport-https', 'libmnl0'],
+    },
     'sid': {
         'pkgs': ['python3-apt', 'apt-transport-https', 'libmnl0'],
     },


### PR DESCRIPTION
python3-apt will not be installed on debian-12/bookworm (currently testing).
This PR adds python3-apt to list of system packages - #225 is a fix for bullseye and sid only