### PR TITLE
fix lvm_service package names for centos 8 stream

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -393,6 +393,9 @@ Debian:
          },
     },
 }, merge=salt['grains.filter_by']({
+    'CentOS Stream 8': {
+      'lvm_services': ['lvm2-lvmpolld', 'lvm2-monitor'],
+    },
     'focal': {
       'lvm_services': ['lvm2-monitor'],
     },


### PR DESCRIPTION
lvm_services fail in centos-8-stream.
This PR fixes lvm-services-packages similar to #226 