### PR TITLE
add metric-option to network/interface (for debian only)

### DIFF
--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -269,6 +269,9 @@ linux_interface_{{ interface_name }}:
   {%- if interface.name_servers is defined %}
   - dns: {{ interface.name_servers }}
   {%- endif %}
+  {%- if interface.metric is defined and grains.os_family == 'Debian' %}
+  - metric: {{ interface.metric }}
+  {%- endif %}
   {%- if interface.wireless is defined and grains.os_family == 'Debian' %}
   {%- if interface.wireless.security == "wpa" %}
   - wpa-ssid: {{ interface.wireless.essid }}


### PR DESCRIPTION
This PR adds support for "metric" option for os_family debian, which can be set via pillars like
```
linux:
  network:
    interface:
      eth0:
        metric: 10
```
see https://manpages.debian.org/bullseye/ifupdown/interfaces.5.en.html#metric