### PR TITLE
Update Sorting Function for Python3 sorted()

### DIFF
--- a/_modules/linux_hosts.py
+++ b/_modules/linux_hosts.py
@@ -9,22 +9,12 @@ from jinja2 import Undefined
 def __virtual__():
     return 'linux_hosts'
 
-def fqdn_sort_fn(n1, n2):
-    l1 = n1.split('.')
-    l2 = n2.split('.')
-    if len(l1) > len(l2):
-        return -1
-    if len(l1) < len(l2):
-        return 1
-    for i1, i2 in zip(l1, l2):
-        if i1 < i2:
-            return -1
-        if i1  > i2:
-            return 1
-    return 0
+def fqdn_sort_fn(n1):
+    length = len(n1)
+    return length
 
 def fqdn_sort_filter(iterable):
     if iterable is None or isinstance(iterable, Undefined):
         return iterable
     # Do effective custom sorting of iterable here
-    return sorted(set(iterable), cmp=fqdn_sort_fn)
+    return sorted(set(iterable), key=fqdn_sort_fn)

--- a/linux/system/user.sls
+++ b/linux/system/user.sls
@@ -49,7 +49,7 @@ system_user_{{ name }}:
   {%- if user.gid is defined and user.gid %}
   - gid: {{ user.gid }}
   {%- else %}
-  - gid_from_name: true
+  - gid: {{ name }}
   {%- endif %}
   {%- if user.groups is defined %}
   - groups: {{ user.groups }}


### PR DESCRIPTION
- 'cmp' as a parameter to the sorted() function doesn't exist anymore.
- Instead, we should use 'key', which tells the sorted() function what to sort by.
- Per https://docs.python.org/3/howto/sorting.html#key-functions, we can define a function
to be run against each item in the iterable that will return a value that sorted() will
sort by.
- Since the original function seems to compare lengths in the hostname entries, we can actually
make fqdn_sort_fn() a great deal simpler than it was and get largely the same results.