### PR TITLE
add support for Debian trixie and forky

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -393,6 +393,9 @@ Debian:
          },
     },
 }, merge=salt['grains.filter_by']({
+    'CentOS Stream 8': {
+      'lvm_services': ['lvm2-lvmpolld', 'lvm2-monitor'],
+    },
     'focal': {
       'lvm_services': ['lvm2-monitor'],
     },

--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -393,9 +393,6 @@ Debian:
          },
     },
 }, merge=salt['grains.filter_by']({
-    'CentOS Stream 8': {
-      'lvm_services': ['lvm2-lvmpolld', 'lvm2-monitor'],
-    },
     'focal': {
       'lvm_services': ['lvm2-monitor'],
     },


### PR DESCRIPTION
linux.storage.lvm does not work on trixie or forky systems. This PR sets the correct package and service names, similar to #227 