### PR TITLE
Fix for non-existing grains.lvm 

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -393,6 +393,9 @@ Debian:
          },
     },
 }, merge=salt['grains.filter_by']({
+    'CentOS Stream 8': {
+      'lvm_services': ['lvm2-lvmpolld', 'lvm2-monitor'],
+    },
     'focal': {
       'lvm_services': ['lvm2-monitor'],
     },

--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -393,9 +393,6 @@ Debian:
          },
     },
 }, merge=salt['grains.filter_by']({
-    'CentOS Stream 8': {
-      'lvm_services': ['lvm2-lvmpolld', 'lvm2-monitor'],
-    },
     'focal': {
       'lvm_services': ['lvm2-monitor'],
     },


### PR DESCRIPTION
if there aren’t any volume groups (yet), grains.lvm does not exist, and causes the template to fail.
This PR adds additional checks into the template